### PR TITLE
Fix for regexp quantifier

### DIFF
--- a/data/language-specs/perl.lang
+++ b/data/language-specs/perl.lang
@@ -172,7 +172,7 @@ FIXME: =pod should require an empty line before/after, as written in perlpod
          please look at it, it seems wrong. It probably should be a positive
          look-behind. -->
     <define-regex id="pattern-before" extended="true">
-      (?&lt;![a-zA-Z0-9@%{(])
+      (?&lt;![a-zA-Z0-9@%{(_])
     </define-regex>
 
     <context id="in-pattern">


### PR DESCRIPTION
This fixes the coloring of variables such as $var->{ some_y } where it would start coloring text after _y, thinknig the pattern to follow was the start to a regular expression.
