### PR TITLE
javascript.lang: Add support for .mjs glob

### DIFF
--- a/data/language-specs/javascript.lang
+++ b/data/language-specs/javascript.lang
@@ -26,7 +26,7 @@
 <language id="js" _name="JavaScript" version="2.0" _section="Script">
   <metadata>
     <property name="mimetypes">application/javascript;application/x-javascript;text/x-javascript;text/javascript;text/x-js</property>
-    <property name="globs">*.js;*.node</property>
+    <property name="globs">*.js;*.mjs;*.node</property>
     <property name="line-comment-start">//</property>
     <property name="block-comment-start">/*</property>
     <property name="block-comment-end">*/</property>


### PR DESCRIPTION
Node.js developers will soon be writing ES2015 modules in .mjs files. Node.js 9 has started implementing it, and even earlier versions can support it with [@std/esm](https://github.com/standard-things/esm).

Reference:
https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
https://github.com/standard-things/esm