### PR TITLE
updated changes

### DIFF
--- a/data/language-specs/c.lang
+++ b/data/language-specs/c.lang
@@ -274,7 +274,7 @@
       <keyword>TRUE</keyword>
       <keyword>FALSE</keyword>
       <keyword>__LINE__</keyword>
-      <keyword>__DATA__</keyword>
+      <keyword>__DATE__</keyword>
       <keyword>__FILE__</keyword>
       <keyword>__func__</keyword>
       <keyword>__TIME__</keyword>

--- a/data/language-specs/cpp.lang
+++ b/data/language-specs/cpp.lang
@@ -104,6 +104,16 @@
                 <context id="common-defines" style-ref="common-defines">
                     <keyword>__STDC__</keyword>
                     <keyword>__cplusplus</keyword>
+                    <keyword>__STDC_HOSTED__</keyword>
+                    <keyword>__STDCPP_DEFAULT_NEW_ALIGNMENT__</keyword>
+                    <keyword>__STDC_VERSION__</keyword>
+                    <keyword>__STDC_ISO_10646__</keyword>
+                    <keyword>__STDC_MB_MIGHT_NEQ_WC__</keyword>
+                    <keyword>__STDCPP_STRICT_POINTER_SAFETY__</keyword>
+                    <keyword>__STDCPP_THREADS__</keyword>
+                    <keyword>__VERSION__</keyword>
+                    <keyword>__OBJC__</keyword>
+                    <keyword>__ASSEMBLER__</keyword>
                 </context>
             </include>
         </context>


### PR DESCRIPTION
I've found an imprecision at line 278 in the file ./language-specs/c.lang
The macro "DATA" doesn't exist. The correct one is "DATE".
And I've updated the ISO C++17 standard macros in the file.language-specs/cpp.lang,
because some were missing.