### PR TITLE
Bring into accordance with F2003/F2008

### DIFF
--- a/data/language-specs/fortran.lang
+++ b/data/language-specs/fortran.lang
@@ -143,41 +143,54 @@
     </context>
 
     <context id="keywords" style-ref="keyword">
-      <keyword>abstract interface</keyword>
+      <keyword>abstract</keyword>
       <keyword>allocate</keyword>
       <keyword>assign</keyword>
       <keyword>assignment</keyword>
-      <keyword>block data</keyword>
+      <keyword>associate</keyword>
+      <keyword>bind</keyword>
+      <keyword>block</keyword>
       <keyword>call</keyword>
       <keyword>case</keyword>
       <keyword>class</keyword>
       <keyword>common</keyword>
+      <keyword>concurrent</keyword>
       <keyword>contains</keyword>
       <keyword>continue</keyword>
+      <keyword>critical<keyword>
       <keyword>cycle</keyword>
       <keyword>data</keyword>
       <keyword>deallocate</keyword>
       <keyword>default</keyword>
       <keyword>do</keyword>
-      <keyword>do concurrent</keyword>
       <keyword>elemental</keyword>
       <keyword>elseif</keyword>
       <keyword>else</keyword>
       <keyword>elsewhere</keyword>
+      <keyword>endassociate</keyword>
+      <keyword>endblock</keyword>
+      <keyword>endcritical</keyword>
       <keyword>enddo</keyword>
       <keyword>endif</keyword>
       <keyword>endselect</keyword>
       <keyword>end</keyword>
+      <keyword>enum</keyword>
       <keyword>entry</keyword>
       <keyword>equivalence</keyword>
+      <keyword>error stop</keyword>
       <keyword>exit</keyword>
+      <keyword>extends</keyword>
       <keyword>external</keyword>
+      <keyword>final</keyword>
       <keyword>forall</keyword>
       <keyword>function</keyword>
+      <keyword>generic</keyword>
       <keyword>go to</keyword>
       <keyword>goto</keyword>
       <keyword>if</keyword>
       <keyword>implicit none</keyword>
+      <keyword>implicit</keyword>
+      <keyword>import</keyword>
       <keyword>in</keyword>
       <keyword>[^#]include</keyword>
       <keyword>inout</keyword>
@@ -185,6 +198,7 @@
       <keyword>intrinsic</keyword>
       <keyword>kind</keyword>
       <keyword>len</keyword>
+      <keyword>lock</keyword>
       <keyword>module</keyword>
       <keyword>namelist</keyword>
       <keyword>nullify</keyword>
@@ -202,9 +216,14 @@
       <keyword>save</keyword>
       <keyword>select</keyword>
       <keyword>stop</keyword>
+      <keyword>submodule>
       <keyword>subroutine</keyword>
+      <keyword>sync all</keyword>
+      <keyword>sync images</keyword>
+      <keyword>sync memory</keyword>
       <keyword>then</keyword>
       <keyword>type</keyword>
+      <keyword>unlock</keyword>
       <keyword>use</keyword>
       <keyword>where</keyword>
       <keyword>while</keyword>
@@ -220,6 +239,7 @@
       <keyword>print</keyword>
       <keyword>read</keyword>
       <keyword>rewind</keyword>
+      <keyword>wait</keyword>
       <keyword>write</keyword>
     </context>
 
@@ -242,6 +262,7 @@
       <keyword>iostat</keyword>
       <keyword>name</keyword>
       <keyword>named</keyword>
+      <keyword>newunit</keyword>
       <keyword>nextrec</keyword>
       <keyword>nml</keyword>
       <keyword>number</keyword>
@@ -261,6 +282,7 @@
     <context id="intrinsics" style-ref="intrinsic">
       <keyword>abs</keyword>
       <keyword>achar</keyword>
+      <keyword>acosh</keyword>
       <keyword>acos</keyword>
       <keyword>adjustl</keyword>
       <keyword>adjustr</keyword>
@@ -278,10 +300,24 @@
       <keyword>amod</keyword>
       <keyword>anint</keyword>
       <keyword>any</keyword>
+      <keyword>asinh</keyword>
       <keyword>asin</keyword>
       <keyword>associated</keyword>
       <keyword>atan2</keyword>
+      <keyword>atanh</keyword>
       <keyword>atan</keyword>
+      <keyword>atomic_define</keyword>
+      <keyword>atomic_ref</keyword>
+      <keyword>bessel_j0</keyword>
+      <keyword>bessel_j1</keyword>
+      <keyword>bessel_jn</keyword>
+      <keyword>bessel_y0</keyword>
+      <keyword>bessel_y1</keyword>
+      <keyword>bessel_yn</keyword>
+      <keyword>bge</keyword>
+      <keyword>bgt</keyword>
+      <keyword>ble</keyword>
+      <keyword>blt</keyword>
       <keyword>bit_size</keyword>
       <keyword>btest</keyword>
       <keyword>c_associated</keyword>
@@ -347,6 +383,8 @@
       <keyword>dnint</keyword>
       <keyword>dot_product</keyword>
       <keyword>dprod</keyword>
+      <keyword>dshiftl</keyword>
+      <keyword>dshiftr</keyword>
       <keyword>dsign</keyword>
       <keyword>dsinh</keyword>
       <keyword>dsin</keyword>
@@ -355,12 +393,16 @@
       <keyword>dtan</keyword>
       <keyword>eoshift</keyword>
       <keyword>epsilon</keyword>
+      <keyword>erfc_scaled</keyword>
       <keyword>erfc</keyword>
       <keyword>erf</keyword>
+      <keyword>execute_command_line</keyword>
       <keyword>exp</keyword>
       <keyword>exponent</keyword>
+      <keyword>findloc</keyword>
       <keyword>float</keyword>
       <keyword>floor</keyword>
+      <keyword>flush</keyword>
       <keyword>fraction</keyword>
       <keyword>gamma</keyword>
       <keyword>getarg</keyword>
@@ -368,9 +410,12 @@
       <keyword>get_command_argument</keyword>
       <keyword>get_environment_variable</keyword>
       <keyword>huge</keyword>
+      <keyword>hypot</keyword>
       <keyword>iabs</keyword>
       <keyword>iachar</keyword>
+      <keyword>iall</keyword>
       <keyword>iand</keyword>
+      <keyword>iany</keyword>
       <keyword>iargc</keyword>
       <keyword>ibclr</keyword>
       <keyword>ibits</keyword>
@@ -379,12 +424,47 @@
       <keyword>idim</keyword>
       <keyword>idint</keyword>
       <keyword>idnint</keyword>
+      <keyword>ieee_class</keyword>
+      <keyword>ieee_copy_sign</keyword>
+      <keyword>ieee_get_flag</keyword>
+      <keyword>ieee_get_halting_mode</keyword>
+      <keyword>ieee_get_rounding_mode</keyword>
+      <keyword>ieee_get_status</keyword>
+      <keyword>ieee_is_finite</keyword>
+      <keyword>ieee_is_nan</keyword>
+      <keyword>ieee_is_negative</keyword>
+      <keyword>ieee_is_normal</keyword>
+      <keyword>ieee_logb</keyword>
+      <keyword>ieee_next_after</keyword>
+      <keyword>ieee_rem</keyword>
+      <keyword>ieee_rint</keyword>
+      <keyword>ieee_scalb</keyword>
+      <keyword>ieee_selected_real_kind</keyword>
+      <keyword>ieee_set_flag</keyword>
+      <keyword>ieee_set_halting_mode</keyword>
+      <keyword>ieee_set_rounding_mode</keyword>
+      <keyword>ieee_set_status</keyword>
+      <keyword>ieee_support_datatype</keyword>
+      <keyword>ieee_support_denormal</keyword>
+      <keyword>ieee_support_divide</keyword>
+      <keyword>ieee_support_flag</keyword>
+      <keyword>ieee_support_halting</keyword>
+      <keyword>ieee_support_inf</keyword>
+      <keyword>ieee_support_nan</keyword>
+      <keyword>ieee_support_rounding</keyword>
+      <keyword>ieee_support_sqrt</keyword>
+      <keyword>ieee_support_standard</keyword>
+      <keyword>ieee_unordered</keyword>
+      <keyword>ieee_value</keyword>
       <keyword>ieor</keyword>
       <keyword>ifix</keyword>
+      <keyword>image_index</keyword>
       <keyword>index</keyword>
       <keyword>int</keyword>
       <keyword>ior</keyword>
+      <keyword>iparity</keyword>
       <keyword>iqint</keyword>
+      <keyword>is_contiguous</keyword>
       <keyword>is_iostat_end</keyword>
       <keyword>is_iostat_eor</keyword>
       <keyword>ishftc</keyword>
@@ -392,6 +472,8 @@
       <keyword>isign</keyword>
       <keyword>kind</keyword>
       <keyword>lbound</keyword>
+      <keyword>lcobound</keyword>
+      <keyword>leadz</keyword>
       <keyword>len_trim</keyword>
       <keyword>len</keyword>
       <keyword>lge</keyword>
@@ -399,9 +481,12 @@
       <keyword>lle</keyword>
       <keyword>llt</keyword>
       <keyword>loc</keyword>
+      <keyword>log_gamma</keyword>
       <keyword>log10</keyword>
       <keyword>log</keyword>
       <keyword>logical</keyword>
+      <keyword>maskl</keyword>
+      <keyword>maskr</keyword>
       <keyword>matmul</keyword>
       <keyword>max0</keyword>
       <keyword>max1</keyword>
@@ -409,6 +494,7 @@
       <keyword>maxloc</keyword>
       <keyword>maxval</keyword>
       <keyword>max</keyword>
+      <keyword>merge_bits</keyword>
       <keyword>merge</keyword>
       <keyword>min0</keyword>
       <keyword>min1</keyword>
@@ -426,8 +512,12 @@
       <keyword>norm2</keyword>
       <keyword>not</keyword>
       <keyword>null</keyword>
+      <keyword>num_images</keyword>
       <keyword>or</keyword>
       <keyword>pack</keyword>
+      <keyword>parity</keyword>
+      <keyword>popcnt</keyword>
+      <keyword>poppar</keyword>
       <keyword>precision</keyword>
       <keyword>present</keyword>
       <keyword>product</keyword>
@@ -474,6 +564,9 @@
       <keyword>selected_real_kind</keyword>
       <keyword>set_exponent</keyword>
       <keyword>shape</keyword>
+      <keyword>shifta</keyword>
+      <keyword>shiftl</keyword>
+      <keyword>shiftr</keyword>
       <keyword>sign</keyword>
       <keyword>sinh</keyword>
       <keyword>sin</keyword>
@@ -482,15 +575,19 @@
       <keyword>spacing</keyword>
       <keyword>spread</keyword>
       <keyword>sqrt</keyword>
+      <keyword>storage-size</keyword>
       <keyword>sum</keyword>
       <keyword>system_clock</keyword>
       <keyword>tanh</keyword>
       <keyword>tan</keyword>
+      <keyword>this_image</keyword>
       <keyword>tiny</keyword>
+      <keyword>trailz</keyword>
       <keyword>transfer</keyword>
       <keyword>transpose</keyword>
       <keyword>trim</keyword>
       <keyword>ubound</keyword>
+      <keyword>ucobound</keyword>
       <keyword>unpack</keyword>
       <keyword>verify</keyword>
       <keyword>zabs</keyword>
@@ -507,6 +604,7 @@
       <keyword>complex</keyword>
       <keyword>double complex</keyword>
       <keyword>double precision</keyword>
+      <keyword>enumerator<keyword>
       <keyword>integer</keyword>
       <keyword>logical</keyword>
       <keyword>procedure</keyword>
@@ -515,17 +613,28 @@
 
     <context id="type-attributes" style-ref="type">
       <keyword>allocatable</keyword>
+      <keyword>asynchronous</keyword>
+      <keyword>codimension</keyword>
+      <keyword>contiguous</keyword>
+      <keyword>deferred</keyword>
       <keyword>dimension</keyword>
       <keyword>external</keyword>
       <keyword>intent</keyword>
       <keyword>intrinsic</keyword>
+      <keyword>non_overridable</keyword>
+      <keyword>nopass</keyword>
       <keyword>optional</keyword>
       <keyword>parameter</keyword>
+      <keyword>pass</keyword>
       <keyword>pointer</keyword>
       <keyword>private</keyword>
+      <keyword>protected</keyword>
       <keyword>public</keyword>
       <keyword>save</keyword>
+      <keyword>synchronous</keyword>
       <keyword>target</keyword>
+      <keyword>value</keyword>
+      <keyword>volatile</keyword>
     </context>
 
     <context id="attributes">


### PR DESCRIPTION
I've added all the keywords, intrinsic functions, and attributes from F2003 and F2008 that I could find, including from the IEEE intrinsic modules.

Some open questions:
* I removed some entries with spaces due to keywords gaining more usage (e.g. `block` and `abstract`). Am I correctly interpreting the parsing logic by my ordering of the keywords in the list?
* Did I miss any `end*` single-word tokens? For example, is `endenum` a valid contraction of `end enum`?
* I'm not sure whether `deferred` should go with the "attributes" or the "keywords". I've erred towards "attributes", since in type declarations it is present in the same place as `dimension`, `intent(*)` etc.

More generally, if I missed anything, or if the changes make valid code fail to properly highlight, please let me know.

List of sources include:
http://fortranwiki.org/fortran/show/Intrinsic+procedures
http://fortranwiki.org/fortran/show/Fortran+2008
https://www.nag.co.uk/nagware/np/r62_doc/ieee_arithmetic.html
http://fortranwiki.org/fortran/show/Keywords
And also the F2008 standard document itself.