### PR TITLE
added globs for short-form Groovy file extensions

### DIFF
--- a/data/language-specs/groovy.lang
+++ b/data/language-specs/groovy.lang
@@ -23,7 +23,7 @@
 -->
 <language id="groovy" name="Groovy" version="2.0" _section="Source">
   <metadata>
-    <property name="globs">*.groovy</property>
+    <property name="globs">*.groovy;*.gvy;*.gy;*.gsh</property>
     <property name="line-comment-start">//</property>
     <property name="block-comment-start">/*</property>
     <property name="block-comment-end">*/</property>


### PR DESCRIPTION
These are the filename extensions the Groovy interpreter looks for to run Groovy scripts. Recommending they be added for the sake of thoroughness.