### PR TITLE
Add highlighting for user-defined types

### DIFF
--- a/data/language-specs/c.lang
+++ b/data/language-specs/c.lang
@@ -244,6 +244,7 @@
       <keyword>void</keyword>
       <keyword>wchar_t</keyword>
       <keyword>wint_t</keyword>
+      <keyword>[a-z_][0-9a-z_]+(_t|_T)</keyword>
     </context>
 
     <context id="storage-class" style-ref="storage-class">


### PR DESCRIPTION
The following modifications provides automatic C/C++ syntax highlighting of user-defined types [ending with either "_t" or "_T"](https://stackoverflow.com/questions/231760/what-does-a-type-followed-by-t-underscore-t-represent), as is seen in editors/viewers such as Nano, Micro, Stack Overflow, or within GitHub itself.