### PR TITLE
Aluminium1 color changed for text visibility

### DIFF
--- a/data/styles/tango.xml
+++ b/data/styles/tango.xml
@@ -51,7 +51,7 @@
   <color name="scarletred1"                 value="#ef2929"/>
   <color name="scarletred2"                 value="#cc0000"/>
   <color name="scarletred3"                 value="#a40000"/>
-  <color name="aluminium1"                  value="#eeeeec"/>
+  <color name="aluminium1"                  value="#99999c"/>
   <color name="aluminium2"                  value="#d3d7cf"/>
   <color name="aluminium3"                  value="#babdb6"/>
   <color name="aluminium4"                  value="#888a85"/>


### PR DESCRIPTION
Previously in tango theme selected line text were not visible due to "#eeeeec" color of aluminium1. It changed to lighter "#99999c" value for better text visibility.

previously:
![image](https://user-images.githubusercontent.com/68750285/192026389-37c90288-6a61-49b6-a8e2-f69598bfec35.png)

After my changes:
![image](https://user-images.githubusercontent.com/68750285/192026625-59416f69-1042-4fd2-aa6c-7bd21daeaf3d.png)
